### PR TITLE
Dispatch HtmlForgeX sync after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,16 +126,14 @@ jobs:
         if: steps.ver.outputs.version != '' && secrets.CDNHFX_WORKFLOW_TOKEN != ''
         shell: bash
         env:
-          CDNHFX_WORKFLOW_TOKEN: ${{ secrets.CDNHFX_WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.CDNHFX_WORKFLOW_TOKEN }}
         run: |
           set -euo pipefail
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${CDNHFX_WORKFLOW_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/EvotecIT/HtmlForgeX/dispatches \
-            -d '{"event_type":"htmlextensions-release","client_payload":{"version":"${{ steps.ver.outputs.version }}"}}'
+          gh api \
+            --method POST \
+            repos/EvotecIT/HtmlForgeX/actions/workflows/sync-htmlextensions.yml/dispatches \
+            -f ref=master \
+            -F inputs[version]='${{ steps.ver.outputs.version }}'
 
       - name: Warn when cross-repo workflow token is missing
         if: steps.ver.outputs.version != '' && secrets.CDNHFX_WORKFLOW_TOKEN == ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,22 +123,22 @@ jobs:
           fi
 
       - name: Dispatch HtmlForgeX HTMLExtensions sync
-        if: steps.ver.outputs.version != '' && secrets.HTMLFORGEX_REPO_DISPATCH_TOKEN != ''
+        if: steps.ver.outputs.version != '' && secrets.CDNHFX_WORKFLOW_TOKEN != ''
         shell: bash
         env:
-          HTMLFORGEX_REPO_DISPATCH_TOKEN: ${{ secrets.HTMLFORGEX_REPO_DISPATCH_TOKEN }}
+          CDNHFX_WORKFLOW_TOKEN: ${{ secrets.CDNHFX_WORKFLOW_TOKEN }}
         run: |
           set -euo pipefail
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${HTMLFORGEX_REPO_DISPATCH_TOKEN}" \
+            -H "Authorization: Bearer ${CDNHFX_WORKFLOW_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/EvotecIT/HtmlForgeX/dispatches \
             -d '{"event_type":"htmlextensions-release","client_payload":{"version":"${{ steps.ver.outputs.version }}"}}'
 
-      - name: Warn when HtmlForgeX sync dispatch token is missing
-        if: steps.ver.outputs.version != '' && secrets.HTMLFORGEX_REPO_DISPATCH_TOKEN == ''
+      - name: Warn when cross-repo workflow token is missing
+        if: steps.ver.outputs.version != '' && secrets.CDNHFX_WORKFLOW_TOKEN == ''
         shell: bash
         run: |
-          echo "::warning::HTMLFORGEX_REPO_DISPATCH_TOKEN is not configured, so the HtmlForgeX HTMLExtensions sync workflow was not dispatched."
+          echo "::warning::CDNHFX_WORKFLOW_TOKEN is not configured, so the HtmlForgeX HTMLExtensions sync workflow was not dispatched."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,3 +121,24 @@ jobs:
           else
             echo "package.json missing; skipping npm publish."
           fi
+
+      - name: Dispatch HtmlForgeX HTMLExtensions sync
+        if: steps.ver.outputs.version != '' && secrets.HTMLFORGEX_REPO_DISPATCH_TOKEN != ''
+        shell: bash
+        env:
+          HTMLFORGEX_REPO_DISPATCH_TOKEN: ${{ secrets.HTMLFORGEX_REPO_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${HTMLFORGEX_REPO_DISPATCH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/EvotecIT/HtmlForgeX/dispatches \
+            -d '{"event_type":"htmlextensions-release","client_payload":{"version":"${{ steps.ver.outputs.version }}"}}'
+
+      - name: Warn when HtmlForgeX sync dispatch token is missing
+        if: steps.ver.outputs.version != '' && secrets.HTMLFORGEX_REPO_DISPATCH_TOKEN == ''
+        shell: bash
+        run: |
+          echo "::warning::HTMLFORGEX_REPO_DISPATCH_TOKEN is not configured, so the HtmlForgeX HTMLExtensions sync workflow was not dispatched."


### PR DESCRIPTION
## Summary
- dispatch a repository event to HtmlForgeX after a successful HTMLExtensions release publish
- pass the released HTMLExtensions version in the event payload so HtmlForgeX can sync the matching assets
- reuse the existing CDNHFX_WORKFLOW_TOKEN secret instead of introducing a second cross-repo token

## Why
HtmlForgeX now has a dedicated workflow that can sync released HTMLExtensions DataTables assets into its own resource descriptors and embedded fallbacks. This change wires the sender side so future HTMLExtensions releases can kick off that sync automatically.

## Configuration
- requires the CDNHFX_WORKFLOW_TOKEN secret in the HTMLExtensions repo
- the token needs enough access to dispatch workflows or repository events across the EvotecIT repos involved in automation
