### PR TITLE
[codex] Add toggleView regression tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test HTMLExtensions
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dist
+        run: npm run build
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run regression tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@evotecit/htmlextensions",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@evotecit/htmlextensions",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "devDependencies": {
         "clean-css": "^5.3.3",
+        "playwright": "^1.53.2",
         "prettier": "^3.3.3",
         "rimraf": "^5.0.5",
         "terser": "^5.44.0"
@@ -243,6 +244,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -362,6 +378,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "format": "prettier --write \"sources/**/*.js\"",
     "format:check": "prettier --check \"sources/**/*.js\"",
     "build": "npm run clean && node scripts/build.js",
-    "test": "node --test tests/**/*.test.cjs",
+    "test": "node --test tests/toggleView.regression.test.cjs",
     "prepublishOnly": "npm run format && npm run build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "playwright": "^1.53.2",
     "terser": "^5.44.0",
     "prettier": "^3.3.3",
     "rimraf": "^5.0.5",
@@ -36,6 +37,7 @@
     "format": "prettier --write \"sources/**/*.js\"",
     "format:check": "prettier --check \"sources/**/*.js\"",
     "build": "npm run clean && node scripts/build.js",
+    "test": "node --test tests/**/*.test.cjs",
     "prepublishOnly": "npm run format && npm run build"
   }
 }

--- a/tests/toggleView.regression.test.cjs
+++ b/tests/toggleView.regression.test.cjs
@@ -1,0 +1,241 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+
+const { chromium } = require('playwright');
+
+const distRoot = path.join(__dirname, '..', 'dist');
+const toggleViewScriptPath = path.join(distRoot, 'datatables.toggleView.js');
+
+function createFixtureHtml() {
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>toggleView regression</title>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/responsive/2.5.0/js/dataTables.responsive.min.js"></script>
+    <script src="/dist/datatables.toggleView.js"></script>
+  </head>
+  <body>
+    <table id="tblToggleRegression" style="width: 100%"></table>
+    <script>
+      window.__toggleMetrics = {
+        selectedRowsCalls: 0,
+        selectedColumnsCalls: 0,
+        selectedCellsCalls: 0,
+        initialMode: null,
+        afterFirstMode: null,
+        afterSecondMode: null,
+        searchAfterFirst: null,
+        searchAfterSecond: null,
+        columnSearchAfterFirst: null,
+        columnSearchAfterSecond: null,
+        orderAfterFirst: null,
+        orderAfterSecond: null,
+        hasSelectExtension: null,
+        error: null,
+        done: false
+      };
+
+      (function () {
+        var targetTableId = 'tblToggleRegression';
+        var apiPrototype = $.fn.dataTable.Api.prototype;
+
+        function instrument(methodName, metricName) {
+          var original = apiPrototype[methodName];
+          if (!original || original.__hfxToggleRegressionWrapped) return;
+
+          var wrapped = function () {
+            try {
+              var modifier = arguments[0];
+              var touchesSelection = modifier && typeof modifier === 'object' && modifier.selected === true;
+              var isTargetTable =
+                this &&
+                Array.isArray(this.context) &&
+                this.context.some(function (context) {
+                  return context && context.nTable && context.nTable.id === targetTableId;
+                });
+
+              if (touchesSelection && isTargetTable) {
+                window.__toggleMetrics[metricName] += 1;
+              }
+            } catch (_) {}
+
+            return original.apply(this, arguments);
+          };
+
+          wrapped.__hfxToggleRegressionWrapped = true;
+          apiPrototype[methodName] = wrapped;
+        }
+
+        instrument('rows', 'selectedRowsCalls');
+        instrument('columns', 'selectedColumnsCalls');
+        instrument('cells', 'selectedCellsCalls');
+      })();
+
+      $(function () {
+        try {
+          var rows = [];
+          for (var index = 0; index < 600; index++) {
+            rows.push({
+              Server: 'srv-' + index,
+              Domain: index % 2 === 0 ? 'ad.evotec.xyz' : 'example.local',
+              Site: index % 3 === 0 ? 'Warsaw' : 'Berlin',
+              Score: index,
+              Status: index % 5 === 0 ? 'Degraded' : 'Healthy'
+            });
+          }
+
+          var api = $('#tblToggleRegression').DataTable({
+            data: rows,
+            columns: [
+              { data: 'Server', title: 'Server' },
+              { data: 'Domain', title: 'Domain' },
+              { data: 'Site', title: 'Site' },
+              { data: 'Score', title: 'Score' },
+              { data: 'Status', title: 'Status' }
+            ],
+            paging: true,
+            pageLength: 25,
+            autoWidth: true,
+            responsive: false,
+            scrollX: '100%'
+          });
+
+          window.__toggleMetrics.initialMode = window.hfxToggleViewMode(api, api.init());
+
+          api.search('srv-1');
+          api.column(2).search('Berlin');
+          api.order([[3, 'desc']]).draw();
+
+          var firstToggle = window.hfxToggleView(api);
+          window.__toggleMetrics.afterFirstMode = window.hfxToggleViewMode(firstToggle, firstToggle.init());
+          window.__toggleMetrics.searchAfterFirst = firstToggle.search();
+          window.__toggleMetrics.columnSearchAfterFirst = firstToggle.column(2).search();
+          window.__toggleMetrics.orderAfterFirst = firstToggle.order();
+
+          var secondToggle = window.hfxToggleView(firstToggle);
+          window.__toggleMetrics.afterSecondMode = window.hfxToggleViewMode(secondToggle, secondToggle.init());
+          window.__toggleMetrics.searchAfterSecond = secondToggle.search();
+          window.__toggleMetrics.columnSearchAfterSecond = secondToggle.column(2).search();
+          window.__toggleMetrics.orderAfterSecond = secondToggle.order();
+          window.__toggleMetrics.hasSelectExtension = !!(
+            secondToggle.settings &&
+            secondToggle.settings()[0] &&
+            secondToggle.settings()[0]._select
+          );
+        } catch (error) {
+          window.__toggleMetrics.error = String((error && error.stack) || error);
+        } finally {
+          window.__toggleMetrics.done = true;
+        }
+      });
+    </script>
+  </body>
+</html>`;
+}
+
+async function startServer() {
+  const fixtureHtml = createFixtureHtml();
+
+  const server = http.createServer(async (request, response) => {
+    try {
+      if (!request.url || request.url === '/' || request.url === '/toggleView-regression.html') {
+        response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        response.end(fixtureHtml);
+        return;
+      }
+
+      if (request.url === '/dist/datatables.toggleView.js') {
+        const content = await fs.readFile(toggleViewScriptPath, 'utf8');
+        response.writeHead(200, { 'Content-Type': 'application/javascript; charset=utf-8' });
+        response.end(content);
+        return;
+      }
+
+      response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('Not found');
+    } catch (error) {
+      response.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end(String(error));
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close(error => {
+          if (error) reject(error);
+          else resolve();
+        });
+      })
+  };
+}
+
+test('toggleView skips selection preservation work for non-select tables', async () => {
+  const server = await startServer();
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const pageErrors = [];
+  const consoleErrors = [];
+
+  page.on('pageerror', error => {
+    pageErrors.push(String(error));
+  });
+
+  page.on('console', message => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  try {
+    await page.goto(`${server.baseUrl}/toggleView-regression.html`, {
+      waitUntil: 'networkidle',
+      timeout: 30000
+    });
+
+    await page.waitForFunction(() => window.__toggleMetrics && window.__toggleMetrics.done === true, {
+      timeout: 30000
+    });
+
+    const metrics = await page.evaluate(() => window.__toggleMetrics);
+
+    assert.equal(metrics.error, null);
+    assert.equal(metrics.hasSelectExtension, false);
+
+    assert.equal(metrics.initialMode, 'ScrollX');
+    assert.equal(metrics.afterFirstMode, 'Responsive');
+    assert.equal(metrics.afterSecondMode, 'ScrollX');
+
+    assert.equal(metrics.searchAfterFirst, 'srv-1');
+    assert.equal(metrics.searchAfterSecond, 'srv-1');
+    assert.equal(metrics.columnSearchAfterFirst, 'Berlin');
+    assert.equal(metrics.columnSearchAfterSecond, 'Berlin');
+    assert.deepEqual(metrics.orderAfterFirst, [[3, 'desc']]);
+    assert.deepEqual(metrics.orderAfterSecond, [[3, 'desc']]);
+
+    assert.equal(metrics.selectedRowsCalls, 0);
+    assert.equal(metrics.selectedColumnsCalls, 0);
+    assert.equal(metrics.selectedCellsCalls, 0);
+
+    assert.deepEqual(pageErrors, []);
+    assert.deepEqual(consoleErrors, []);
+  } finally {
+    await page.close();
+    await browser.close();
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add a Playwright-backed regression test for `toggleView` on non-select DataTables
- add a GitHub Actions workflow that builds HTMLExtensions, installs Chromium, and runs the regression suite
- wire in the test dependency and `npm test`

## Why
The `toggleView` performance bug came from preserving selection state on tables that did not use the Select extension. We needed an automated browser check that proves we do not call the selected-row/column/cell paths in that scenario.

## Impact
Future changes to `toggleView` now have a concrete regression that verifies both state preservation and the absence of the expensive non-select selection work.

## Validation
- `npm test`