### PR TITLE
chore: update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           # For npm Trusted Publishing (OIDC), avoid registry auth token wiring here.
@@ -116,11 +116,25 @@ jobs:
           fi
 
       - name: Create GitHub Release and upload assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', steps.ver.outputs.version) }}
-          name: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', steps.ver.outputs.version) }}
-          files: dist/**
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', steps.ver.outputs.version) }}"
+          NAME="$TAG"
+
+          mapfile -t ASSETS < <(find dist -type f | sort)
+          if [ "${#ASSETS[@]}" -eq 0 ]; then
+            echo "No release assets found under dist/." >&2
+            exit 1
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" "${ASSETS[@]}" --clobber
+          else
+            gh release create "$TAG" "${ASSETS[@]}" --title "$NAME"
+          fi
 
       - name: Publish to npm (Trusted Publishing / OIDC)
         run: |

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Mirror raw sources into the published site so examples can import them
       - name: Sync sources -> docs/sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
## Summary
- move remaining workflow actions onto current Node 24-safe releases
- replace the release upload step with gh release so HTMLExtensions no longer depends on a Node 20 action runtime
- keep the existing build, test, pages, and release flow behavior intact

## Verification
- reviewed against the latest official action releases for checkout, setup-node, setup-dotnet, create-pull-request, github-script, and codecov-action
